### PR TITLE
Add TimeTravel example

### DIFF
--- a/Harvest-SwiftUI-Gallery.xcodeproj/project.pbxproj
+++ b/Harvest-SwiftUI-Gallery.xcodeproj/project.pbxproj
@@ -8,10 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		1F199768235AC81300B4F99C /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F199767235AC81300B4F99C /* Either.swift */; };
+		1F2E1F572362A3F90063DA76 /* TimeTravel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2E1F562362A3F90063DA76 /* TimeTravel.swift */; };
 		1F2F06102356E5F400211CF3 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2F060F2356E5F400211CF3 /* WebView.swift */; };
 		1F3CFDAF235B89250088C968 /* IfLetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3CFDAE235B89250088C968 /* IfLetView.swift */; };
 		1F3CFDB1235B968E0088C968 /* IfView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3CFDB0235B968E0088C968 /* IfView.swift */; };
 		1F4DAA29235E6DC7003EAFE1 /* Root.State.Current.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4DAA28235E6DC7003EAFE1 /* Root.State.Current.swift */; };
+		1F5801602363E6500085A6A1 /* DebugRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F58015F2363E6500085A6A1 /* DebugRoot.swift */; };
+		1F5801622363FAE90085A6A1 /* DebugRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5801612363FAE90085A6A1 /* DebugRootView.swift */; };
 		1F58869F2354A3310052A690 /* TodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F58869C2354A3310052A690 /* TodoView.swift */; };
 		1F5886A02354A3310052A690 /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F58869D2354A3310052A690 /* Todo.swift */; };
 		1F5886A12354A3310052A690 /* TodoExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F58869E2354A3310052A690 /* TodoExample.swift */; };
@@ -65,10 +68,13 @@
 
 /* Begin PBXFileReference section */
 		1F199767235AC81300B4F99C /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
+		1F2E1F562362A3F90063DA76 /* TimeTravel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TimeTravel.swift; path = "Harvest-SwiftUI-Gallery/Utilities/TimeTravel.swift"; sourceTree = SOURCE_ROOT; };
 		1F2F060F2356E5F400211CF3 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
 		1F3CFDAE235B89250088C968 /* IfLetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfLetView.swift; sourceTree = "<group>"; };
 		1F3CFDB0235B968E0088C968 /* IfView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfView.swift; sourceTree = "<group>"; };
 		1F4DAA28235E6DC7003EAFE1 /* Root.State.Current.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Root.State.Current.swift; sourceTree = "<group>"; };
+		1F58015F2363E6500085A6A1 /* DebugRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRoot.swift; sourceTree = "<group>"; };
+		1F5801612363FAE90085A6A1 /* DebugRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugRootView.swift; sourceTree = "<group>"; };
 		1F58869C2354A3310052A690 /* TodoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoView.swift; sourceTree = "<group>"; };
 		1F58869D2354A3310052A690 /* Todo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
 		1F58869E2354A3310052A690 /* TodoExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodoExample.swift; sourceTree = "<group>"; };
@@ -126,9 +132,10 @@
 				1F199767235AC81300B4F99C /* Either.swift */,
 				1F63A0A3235B67C8006B4F83 /* Combine+DelaySubscription.swift */,
 				1F63A0A5235B68EC006B4F83 /* SwiftUI+Helper.swift */,
-				1F70A1A52358D2E80028624C /* ImageLoader.swift */,
 				1F91AB8A235CBD310054CE37 /* DateUtil.swift */,
 				1F63A0AF235B7D7F006B4F83 /* Functions.swift */,
+				1F70A1A52358D2E80028624C /* ImageLoader.swift */,
+				1F2E1F562362A3F90063DA76 /* TimeTravel.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -246,6 +253,8 @@
 			isa = PBXGroup;
 			children = (
 				1FC021772352740900C117F9 /* AppView.swift */,
+				1F58015F2363E6500085A6A1 /* DebugRoot.swift */,
+				1F5801612363FAE90085A6A1 /* DebugRootView.swift */,
 				1FD96FD222E0397E005DBB61 /* Root.swift */,
 				1F4DAA28235E6DC7003EAFE1 /* Root.State.Current.swift */,
 				1FD7A6BE22E379E3005130FB /* RootView.swift */,
@@ -354,8 +363,11 @@
 				1FD7A6BF22E379E3005130FB /* RootView.swift in Sources */,
 				1F3CFDAF235B89250088C968 /* IfLetView.swift in Sources */,
 				1FC0218723529DEE00C117F9 /* CounterView.swift in Sources */,
+				1F5801602363E6500085A6A1 /* DebugRoot.swift in Sources */,
+				1F2E1F572362A3F90063DA76 /* TimeTravel.swift in Sources */,
 				1F63A0A4235B67C8006B4F83 /* Combine+DelaySubscription.swift in Sources */,
 				1FC021B22352C55800C117F9 /* StateDiagramExample.swift in Sources */,
+				1F5801622363FAE90085A6A1 /* DebugRootView.swift in Sources */,
 				1FD96FD622E0397E005DBB61 /* StateDiagram.swift in Sources */,
 				1FA2BD7B2356496F0015C530 /* ActivityIndicatorView.swift in Sources */,
 				1F4DAA29235E6DC7003EAFE1 /* Root.State.Current.swift in Sources */,

--- a/Harvest-SwiftUI-Gallery/SceneDelegate.swift
+++ b/Harvest-SwiftUI-Gallery/SceneDelegate.swift
@@ -16,9 +16,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
 
-            let store = Store<Root.Input, Root.State>(
-                state: Root.State(current: nil),
-                mapping: Root.effectMapping(scheduler: DispatchQueue.main)
+            let store = Store<DebugRoot.Input, DebugRoot.State>(
+                state: DebugRoot.State(Root.State(current: nil)),
+                mapping: DebugRoot.effectMapping(scheduler: DispatchQueue.main)
             )
 
             window.rootViewController = UIHostingController(

--- a/Harvest-SwiftUI-Gallery/Screens/AppView.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/AppView.swift
@@ -8,9 +8,9 @@ import HarvestStore
 struct AppView: View
 {
     @ObservedObject
-    private var store: Store<Root.Input, Root.State>
+    private var store: Store<DebugRoot.Input, DebugRoot.State>
 
-    init(store: Store<Root.Input, Root.State>)
+    init(store: Store<DebugRoot.Input, DebugRoot.State>)
     {
         self.store = store
     }
@@ -18,6 +18,6 @@ struct AppView: View
     var body: some View
     {
         // IMPORTANT: Pass `Store.Proxy` to children.
-        RootView(store: store.proxy)
+        DebugRootView(store: self.store.proxy)
     }
 }

--- a/Harvest-SwiftUI-Gallery/Screens/DebugRoot.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/DebugRoot.swift
@@ -1,0 +1,80 @@
+import Combine
+import FunOptics
+import Harvest
+import HarvestOptics
+
+/// DebugRoot namespace.
+enum DebugRoot {}
+
+extension DebugRoot
+{
+    enum Input
+    {
+        case timeTravel(TimeTravel.Input<Root.Input>)
+    }
+
+    struct State
+    {
+        var timeTravel: TimeTravel.State<Root.State>
+
+        /// For debugging purpose.
+        var isDebug: Bool = false
+        {
+            didSet {
+                print("===> Root.State = \(self)".noAppPrefix)
+            }
+        }
+
+        init(_ state: Root.State)
+        {
+            self.timeTravel = .init(inner: state)
+        }
+    }
+
+    static func effectMapping<S: Scheduler>(
+        scheduler: S
+    ) -> EffectMapping
+    {
+        return .reduce(.all, [
+            Root.effectMapping(scheduler: scheduler)
+                .transform(input: fromEnumProperty(\.timeTravel) >>> fromEnumProperty(\.inner))
+                .transform(state: .init(lens: .init(\.timeTravel) >>> .init(\.inner))),
+
+            // Important: TimeTravel mapping needs to be called after `Root.effectMapping` (after `Root.State` changed).
+            TimeTravel.effectMapping(scheduler: scheduler)
+                .transform(input: fromEnumProperty(\.timeTravel))
+                .transform(state: .init(lens: .init(\.timeTravel))),
+        ])
+    }
+
+    typealias EffectMapping = Harvester<Input, State>.EffectMapping<EffectQueue, EffectID>
+    typealias EffectQueue = CommonEffectQueue
+    typealias EffectID = Root.EffectID
+}
+
+// MARK: - Enum Properties
+
+extension DebugRoot.Input
+{
+    var timeTravel: TimeTravel.Input<Root.Input>?
+    {
+        get {
+            guard case let .timeTravel(value) = self else { return nil }
+            return value
+        }
+        set {
+            guard case .timeTravel = self, let newValue = newValue else { return }
+            self = .timeTravel(newValue)
+        }
+    }
+}
+
+// MARK: - Private
+
+extension String
+{
+    fileprivate var noAppPrefix: String
+    {
+        self.replacingOccurrences(of: "Harvest_SwiftUI_Gallery.", with: "")
+    }
+}

--- a/Harvest-SwiftUI-Gallery/Screens/DebugRootView.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/DebugRootView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+import Harvest
+import HarvestStore
+
+struct DebugRootView: View
+{
+    private let store: Store<DebugRoot.Input, DebugRoot.State>.Proxy
+
+    init(store: Store<DebugRoot.Input, DebugRoot.State>.Proxy)
+    {
+        self.store = store
+    }
+
+    var body: some View
+    {
+        VStack {
+            RootView(store: self.store.timeTravel.inner.contramapInput { DebugRoot.Input.timeTravel(.inner($0)) })
+
+            Divider()
+
+            debugBottomView()
+        }
+    }
+
+    private func debugBottomView() -> some View
+    {
+        VStack(alignment: .leading) {
+//            HStack {
+//                Toggle("Debug", isOn: store.$state.isDebug)
+//            }
+//
+//            Divider()
+
+            timeTravelHeader()
+
+            HStack {
+                timeTravelSlider()
+                timeTravelStepper()
+            }
+        }
+        .padding()
+    }
+
+    private func timeTravelHeader() -> some View
+    {
+        HStack {
+            Text("⏱ TIME TRAVEL ⌛").bold()
+            Spacer()
+            Button("Reset", action: { self.store.send(.timeTravel(.resetHistories)) })
+        }
+    }
+
+    private func timeTravelSlider() -> some View
+    {
+        HStack {
+            Slider(
+                value: self.store.timeTravel.timeTravellingSliderValue
+                    .stateBinding(onChange: {
+                        DebugRoot.Input.timeTravel(.timeTravelSlider(sliderValue: $0))
+                    }),
+                in: self.store.state.timeTravel.timeTravellingSliderRange,
+                step: 1
+            )
+                .disabled(!self.store.state.timeTravel.canTimeTravel)
+
+            Text("\(self.store.state.timeTravel.timeTravellingIndex) / \(Int(self.store.state.timeTravel.timeTravellingSliderRange.upperBound))")
+                .font(Font.body.monospacedDigit())
+                .frame(minWidth: 80, alignment: .center)
+        }
+    }
+
+    private func timeTravelStepper() -> some View
+    {
+        Stepper(
+            onIncrement: { self.store.send(.timeTravel(.timeTravelStepper(diff: 1))) },
+            onDecrement: { self.store.send(.timeTravel(.timeTravelStepper(diff: -1))) }
+        ) {
+            EmptyView()
+        }
+        .frame(width: 100)
+    }
+}
+
+struct DebugRootView_Previews: PreviewProvider
+{
+    static var previews: some View
+    {
+        return Group {
+            DebugRootView(
+                store: .init(
+                    state: .constant(DebugRoot.State(Root.State())),
+                    send: { _ in }
+                )
+            )
+                .previewLayout(.fixed(width: 320, height: 480))
+                .previewDisplayName("Root")
+        }
+    }
+}

--- a/Harvest-SwiftUI-Gallery/Screens/RootView.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/RootView.swift
@@ -26,6 +26,8 @@ struct RootView: View
                                     isPresenting ? example.exampleInitialState : nil
                                 }
                             )
+                            // Workaround for SwiftUI's duplicated `isPresenting = false` calls per 1 dismissal.
+                            .removeDuplictates()
                     ) {
                         HStack(alignment: .firstTextBaseline) {
                             example.exampleIcon
@@ -38,13 +40,6 @@ struct RootView: View
                 }
                 .navigationBarTitle(Text("🌾 Harvest Gallery 🖼️"), displayMode: .large)
             }
-
-//            Divider()
-//
-//            Toggle(isOn: store.$state.isDebug) {
-//                Text("Debug Mode")
-//            }
-//            .padding(.horizontal)
         }
     }
 }

--- a/Harvest-SwiftUI-Gallery/Screens/Todo/Todo.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/Todo/Todo.swift
@@ -99,9 +99,7 @@ extension Todo
         var intValue: Int
         {
             get { self.rawValue }
-            set {
-                // Do nothing. This setter will be replaced via `Store.Proxy.stateBinding(get:onChange:)`.
-            }
+            set { assertionFailure("Should be replaced by `Store.Proxy.stateBinding`") }
         }
 
         fileprivate var filter: (Item) -> Bool

--- a/Harvest-SwiftUI-Gallery/Screens/Todo/TodoView.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/Todo/TodoView.swift
@@ -46,11 +46,16 @@ struct TodoView: View
 
             TextField(
                 "Create a new TODO",
+
                 // IMPORTANT:
                 // Explicit subscript access helper is required to avoid
                 // `SwiftUI.BindingOperations.ForceUnwrapping` failure crash.
                 // This issue occurs when `TodoView` is navigation-poped.
-                text: self.store.$state[\.newText],
+                //text: self.store.$state[\.newText],
+
+                // Or, use `stateBinding(onChange:)` with providing an explicit next `Input`.
+                // NOTE: This also allows to time-travel each character inputting.
+                text: self.store.newText.stateBinding(onChange: Todo.Input.updateNewText),
                 onCommit: { self.store.send(.createTodo) }
             )
                 .textFieldStyle(RoundedBorderTextFieldStyle())

--- a/Harvest-SwiftUI-Gallery/Utilities/SwiftUI+Helper.swift
+++ b/Harvest-SwiftUI-Gallery/Utilities/SwiftUI+Helper.swift
@@ -7,3 +7,23 @@ extension View
         AnyView(self)
     }
 }
+
+extension Binding where Value: Equatable
+{
+    /// Workaround for `NavigationLink's `isActive = false` called multiple times per dismissal.
+    public func removeDuplictates() -> Binding<Value>
+    {
+        var previous: Value? = nil
+
+        return Binding<Value>(
+            get: { self.wrappedValue },
+            set: { newValue in
+                guard newValue != previous else {
+                    return
+                }
+                previous = newValue
+                self.wrappedValue = newValue
+            }
+        )
+    }
+}

--- a/Harvest-SwiftUI-Gallery/Utilities/TimeTravel.swift
+++ b/Harvest-SwiftUI-Gallery/Utilities/TimeTravel.swift
@@ -1,0 +1,192 @@
+import Combine
+import Harvest
+import FunOptics
+
+/// Simple time-traveller for Harvest Architecture.
+enum TimeTravel {}
+
+extension TimeTravel
+{
+    enum Input<InnerInput>
+    {
+        case timeTravelStepper(diff: Int)
+        case timeTravelSlider(sliderValue: Double)
+        case _didTimeTravel
+        case resetHistories
+
+        case inner(InnerInput)
+    }
+
+    struct State<InnerState>
+    {
+        var inner: InnerState
+
+        fileprivate(set) var histories: [InnerState] = []
+
+        fileprivate(set) var timeTravellingIndex: Int = 0
+
+        // Workaround flag for avoiding SwiftUI iOS navigation binding issue
+        // where `isActive = false` binding is called during time-travelling.
+        fileprivate(set) var isTimeTravelling: Bool = false
+
+        init(inner: InnerState)
+        {
+            self.inner = inner
+            self.histories.append(inner)
+        }
+
+        var timeTravellingSliderRange: ClosedRange<Double>
+        {
+            let count = self.histories.count
+
+            // NOTE: `0 ... 0` is not allowed in `Slider`.
+            return count > 1
+                ? 0 ... Double(count - 1)
+                : -1 ... 0
+        }
+
+        var timeTravellingSliderValue: Double
+        {
+            get { Double(timeTravellingIndex) }
+            set { assertionFailure("Should be replaced by `Store.Proxy.stateBinding`") }
+        }
+
+        var canTimeTravel: Bool
+        {
+            self.histories.count > 1
+        }
+
+        mutating func appendHistory(_ state: InnerState)
+        {
+            self.histories.removeSubrange((self.timeTravellingIndex + 1)...)
+            self.histories.append(state)
+            self.timeTravellingIndex += 1
+        }
+    }
+
+    /// - Important: This mapping needs to be called after `InnerState` has changed.
+    static func effectMapping<InnerInput, InnerState, Queue: EffectQueueProtocol, ID, S: Scheduler>(
+        scheduler: S
+    ) -> Harvester<Input<InnerInput>, State<InnerState>>.EffectMapping<Queue, ID>
+    {
+        func tryTimeTravel(state: inout State<InnerState>, newIndex: Int) -> Effect<Input<InnerInput>, Queue, ID>?
+        {
+            guard !state.histories.isEmpty && newIndex >= 0 && newIndex < state.histories.count else {
+                return nil
+            }
+
+            // Load history.
+            state.inner = state.histories[newIndex]
+
+            // NOTE: Modify other states after history is loaded.
+            state.timeTravellingIndex = newIndex
+            state.isTimeTravelling = true
+
+            // Workaround effect for changing to `isTimeTravelling = false` after delay.
+            return Effect(
+                Just(Input._didTimeTravel)
+                    .delay(for: .seconds(0.1), scheduler: scheduler)
+            )
+        }
+
+        return .makeInout { input, state in
+            switch input {
+            case let .timeTravelSlider(sliderValue):
+                guard sliderValue >= 0 else { return nil }
+
+                let newIndex = Int(sliderValue)
+                return tryTimeTravel(state: &state, newIndex: newIndex)
+
+            case let .timeTravelStepper(diff):
+                guard diff != 0 else { return nil }
+
+                let newIndex = state.timeTravellingIndex + diff
+                return tryTimeTravel(state: &state, newIndex: newIndex)
+
+            case ._didTimeTravel:
+                state.isTimeTravelling = false
+
+            case .resetHistories:
+                state.histories.removeAll()
+                state.histories.append(state.inner)
+                state.timeTravellingIndex = 0
+
+            default:
+                // IMPORTANT:
+                // Guard `appendHistory` while `isTimeTravelling` to avoid SwiftUI iOS navigation binding issue
+                // where `isActive = false` binding is called during time-travelling.
+                guard !state.isTimeTravelling else {
+                    return nil
+                }
+
+                state.appendHistory(state.inner)
+            }
+
+            return .empty
+        }
+    }
+
+    typealias EffectMapping<InnerInput, InnerState, EffectQueue, EffectID>
+        = Harvester<Input<InnerInput>, State<InnerState>>.EffectMapping<EffectQueue, EffectID>
+        where EffectQueue: EffectQueueProtocol, EffectID: Equatable
+
+}
+
+// MARK: - Enum Properties
+
+extension TimeTravel.Input
+{
+    var timeTravelStepper: Int?
+    {
+        get {
+            guard case let .timeTravelStepper(value) = self else { return nil }
+            return value
+        }
+        set {
+            guard case .timeTravelStepper = self, let newValue = newValue else { return }
+            self = .timeTravelStepper(diff: newValue)
+        }
+    }
+
+    var timeTravelSlider: Double?
+    {
+        get {
+            guard case let .timeTravelSlider(value) = self else { return nil }
+            return value
+        }
+        set {
+            guard case .timeTravelSlider = self, let newValue = newValue else { return }
+            self = .timeTravelSlider(sliderValue: newValue)
+        }
+    }
+
+    var _didTimeTravel: Void?
+    {
+        guard case ._didTimeTravel = self else { return nil }
+        return ()
+    }
+
+    var resetHistories: Void?
+    {
+        get {
+            guard case .resetHistories = self else { return nil }
+            return ()
+        }
+        set {
+            guard case .resetHistories = self, case .some = newValue else { return }
+            self = .resetHistories
+        }
+    }
+
+    var inner: InnerInput?
+    {
+        get {
+            guard case let .inner(value) = self else { return nil }
+            return value
+        }
+        set {
+            guard case .inner = self, let newValue = newValue else { return }
+            self = .inner(newValue)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds `TimeTravel` feature that we can traverse previous histories using Harvest.

Screencast: TBD

### Warning
Unfortunately, SwiftUI's navigation binding is quite broken 💔 (especially in macOS as reported in #1 ).
In iOS, TimeTravel feature barely works by adding some workaround code, but **it's not 100% safe**.