### PR TITLE
Inject `urlSession` from `effectMapping` constructors

### DIFF
--- a/Harvest-SwiftUI-Gallery/SceneDelegate.swift
+++ b/Harvest-SwiftUI-Gallery/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 
             let store = Store<DebugRoot.Input, DebugRoot.State>(
                 state: DebugRoot.State(Root.State(current: nil)),
-                mapping: DebugRoot.effectMapping(scheduler: DispatchQueue.main)
+                mapping: DebugRoot.effectMapping(urlSession: .shared, scheduler: DispatchQueue.main)
             )
 
             window.rootViewController = UIHostingController(

--- a/Harvest-SwiftUI-Gallery/Screens/DebugRoot.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/DebugRoot.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Combine
 import FunOptics
 import Harvest
@@ -32,11 +33,12 @@ extension DebugRoot
     }
 
     static func effectMapping<S: Scheduler>(
+        urlSession: URLSession,
         scheduler: S
     ) -> EffectMapping
     {
         return .reduce(.all, [
-            Root.effectMapping(scheduler: scheduler)
+            Root.effectMapping(urlSession: urlSession, scheduler: scheduler)
                 .transform(input: fromEnumProperty(\.timeTravel) >>> fromEnumProperty(\.inner))
                 .transform(state: .init(lens: .init(\.timeTravel) >>> .init(\.inner))),
 

--- a/Harvest-SwiftUI-Gallery/Screens/GitHub/GitHub.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/GitHub/GitHub.swift
@@ -69,6 +69,7 @@ extension GitHub
     }
 
     static func effectMapping<S: Scheduler>(
+        urlSession: URLSession,
         scheduler: S,
         maxConcurrency: Subscribers.Demand
     ) -> EffectMapping
@@ -77,12 +78,12 @@ extension GitHub
             switch input {
             case .onAppear:
                 state.isLoading = true
-                return githubRequest(text: state.searchText, scheduler: scheduler)
+                return githubRequest(text: state.searchText, urlSession: urlSession, scheduler: scheduler)
 
             case let .updateSearchText(text):
                 state.searchText = text
                 state.isLoading = !text.isEmpty
-                return githubRequest(text: text, scheduler: scheduler)
+                return githubRequest(text: text, urlSession: urlSession, scheduler: scheduler)
 
             case let ._updateItems(items):
                 state.items = items
@@ -130,6 +131,7 @@ extension GitHub
 
     private static func githubRequest<_EffectID: Equatable, S: Scheduler>(
         text: String,
+        urlSession: URLSession,
         scheduler: S
     ) -> Effect<Input, EffectQueue, _EffectID>
     {
@@ -150,7 +152,7 @@ extension GitHub
 
         // Search request.
         // NOTE: `delaySubscription` + `EffectQueue.request` (`.latest` strategy) will work as `debounce`.
-        let publisher = URLSession.shared.dataTaskPublisher(for: request)
+        let publisher = urlSession.dataTaskPublisher(for: request)
             .delaySubscription(for: .seconds(0.3), scheduler: scheduler)
             .map { $0.data }
             .decode(type: SearchRepositoryResponse.self, decoder: decoder)

--- a/Harvest-SwiftUI-Gallery/Screens/Root.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/Root.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Combine
 import FunOptics
 import Harvest
@@ -34,6 +35,7 @@ extension Root
     }
 
     static func effectMapping<S: Scheduler>(
+        urlSession: URLSession,
         scheduler: S
     ) -> EffectMapping
     {
@@ -59,7 +61,7 @@ extension Root
                 .transform(state: Lens(\.current) >>> some() >>> fromEnumProperty(\.stopwatch))
                 .transform(id: .init(tryGet: { $0.stopwatch }, inject: EffectID.stopwatch)),
 
-            GitHub.effectMapping(scheduler: scheduler, maxConcurrency: .max(3))
+            GitHub.effectMapping(urlSession: urlSession, scheduler: scheduler, maxConcurrency: .max(3))
                 .transform(input: fromEnumProperty(\.github))
                 .transform(state: Lens(\.current) >>> some() >>> fromEnumProperty(\.github))
                 .transform(id: .init(tryGet: { $0.github }, inject: EffectID.github)),


### PR DESCRIPTION
This PR injects `urlSession` from outside of `effectMapping` by adding a constructor injection parameter, as questioned from @thomvis :
https://twitter.com/thomvis/status/1189262950642663424

By the way, instead of passing around those dependencies, using a singleton as their container e.g. https://www.pointfree.co/blog/posts/21-how-to-control-the-world is also a valid and simpler solution.