### PR TITLE
Add .github/workflows/main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches:    
+      - master
+      - ci/**
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Select Xcode version
+      run: sudo xcode-select -s '/Applications/Xcode_11.1.app'
+    - name: Build iOS
+      run: xcodebuild -configuration Debug -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11" -scheme "Harvest-SwiftUI-Gallery" build


### PR DESCRIPTION
For Xcode iOS build CI.

See Also: [Use SPM to build iOS target \- Development / Package Manager \- Swift Forums](https://forums.swift.org/t/use-spm-to-build-ios-target/25436/12)

> xcodebuild can build Swift Package without .xcodeproj with passing product name to -scheme option and also recognizes -destination option.