### PR TITLE
Revert "Inject `urlSession` from `effectMapping` constructors"

### DIFF
--- a/Harvest-SwiftUI-Gallery/SceneDelegate.swift
+++ b/Harvest-SwiftUI-Gallery/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 
             let store = Store<DebugRoot.Input, DebugRoot.State>(
                 state: DebugRoot.State(Root.State(current: nil)),
-                mapping: DebugRoot.effectMapping(urlSession: .shared, scheduler: DispatchQueue.main)
+                mapping: DebugRoot.effectMapping(scheduler: DispatchQueue.main)
             )
 
             window.rootViewController = UIHostingController(

--- a/Harvest-SwiftUI-Gallery/Screens/DebugRoot.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/DebugRoot.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Combine
 import FunOptics
 import Harvest
@@ -33,12 +32,11 @@ extension DebugRoot
     }
 
     static func effectMapping<S: Scheduler>(
-        urlSession: URLSession,
         scheduler: S
     ) -> EffectMapping
     {
         return .reduce(.all, [
-            Root.effectMapping(urlSession: urlSession, scheduler: scheduler)
+            Root.effectMapping(scheduler: scheduler)
                 .transform(input: fromEnumProperty(\.timeTravel) >>> fromEnumProperty(\.inner))
                 .transform(state: .init(lens: .init(\.timeTravel) >>> .init(\.inner))),
 

--- a/Harvest-SwiftUI-Gallery/Screens/GitHub/GitHub.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/GitHub/GitHub.swift
@@ -69,7 +69,6 @@ extension GitHub
     }
 
     static func effectMapping<S: Scheduler>(
-        urlSession: URLSession,
         scheduler: S,
         maxConcurrency: Subscribers.Demand
     ) -> EffectMapping
@@ -78,12 +77,12 @@ extension GitHub
             switch input {
             case .onAppear:
                 state.isLoading = true
-                return githubRequest(text: state.searchText, urlSession: urlSession, scheduler: scheduler)
+                return githubRequest(text: state.searchText, scheduler: scheduler)
 
             case let .updateSearchText(text):
                 state.searchText = text
                 state.isLoading = !text.isEmpty
-                return githubRequest(text: text, urlSession: urlSession, scheduler: scheduler)
+                return githubRequest(text: text, scheduler: scheduler)
 
             case let ._updateItems(items):
                 state.items = items
@@ -131,7 +130,6 @@ extension GitHub
 
     private static func githubRequest<_EffectID: Equatable, S: Scheduler>(
         text: String,
-        urlSession: URLSession,
         scheduler: S
     ) -> Effect<Input, EffectQueue, _EffectID>
     {
@@ -152,7 +150,7 @@ extension GitHub
 
         // Search request.
         // NOTE: `delaySubscription` + `EffectQueue.request` (`.latest` strategy) will work as `debounce`.
-        let publisher = urlSession.dataTaskPublisher(for: request)
+        let publisher = URLSession.shared.dataTaskPublisher(for: request)
             .delaySubscription(for: .seconds(0.3), scheduler: scheduler)
             .map { $0.data }
             .decode(type: SearchRepositoryResponse.self, decoder: decoder)

--- a/Harvest-SwiftUI-Gallery/Screens/Root.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/Root.swift
@@ -1,4 +1,3 @@
-import Foundation
 import Combine
 import FunOptics
 import Harvest
@@ -35,7 +34,6 @@ extension Root
     }
 
     static func effectMapping<S: Scheduler>(
-        urlSession: URLSession,
         scheduler: S
     ) -> EffectMapping
     {
@@ -61,7 +59,7 @@ extension Root
                 .transform(state: Lens(\.current) >>> some() >>> fromEnumProperty(\.stopwatch))
                 .transform(id: .init(tryGet: { $0.stopwatch }, inject: EffectID.stopwatch)),
 
-            GitHub.effectMapping(urlSession: urlSession, scheduler: scheduler, maxConcurrency: .max(3))
+            GitHub.effectMapping(scheduler: scheduler, maxConcurrency: .max(3))
                 .transform(input: fromEnumProperty(\.github))
                 .transform(state: Lens(\.current) >>> some() >>> fromEnumProperty(\.github))
                 .transform(id: .init(tryGet: { $0.github }, inject: EffectID.github)),


### PR DESCRIPTION
This reverts #4 commit e69f582d41f08230487766c2a105523b2bf0b171.

Replacing to a better implementation introduced in https://github.com/inamiy/Harvest/pull/23 .