### PR TITLE
Make each screen's `effectMapping` as pure function

### DIFF
--- a/Harvest-SwiftUI-Gallery/SceneDelegate.swift
+++ b/Harvest-SwiftUI-Gallery/SceneDelegate.swift
@@ -18,8 +18,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 
             let store = Store<DebugRoot.Input, DebugRoot.State>(
                 state: DebugRoot.State(Root.State(current: nil)),
-                mapping: DebugRoot.effectMapping(scheduler: DispatchQueue.main),
-                world: World.makeRealWorld()
+                mapping: DebugRoot.effectMapping(),
+                world: makeRealWorld()
             )
 
             window.rootViewController = UIHostingController(

--- a/Harvest-SwiftUI-Gallery/Screens/DebugRoot.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/DebugRoot.swift
@@ -31,23 +31,22 @@ extension DebugRoot
         }
     }
 
-    static func effectMapping<S: Scheduler>(
-        scheduler: S
-    ) -> EffectMapping
+    static func effectMapping<S: Scheduler>() -> EffectMapping<S>
     {
         return .reduce(.all, [
-            Root.effectMapping(scheduler: scheduler)
+            Root.effectMapping()
                 .transform(input: fromEnumProperty(\.timeTravel) >>> fromEnumProperty(\.inner))
                 .transform(state: .init(lens: .init(\.timeTravel) >>> .init(\.inner))),
 
             // Important: TimeTravel mapping needs to be called after `Root.effectMapping` (after `Root.State` changed).
-            TimeTravel.effectMapping(scheduler: scheduler)
+            TimeTravel.effectMapping()
+                .contramapWorld { TimeTravel.World(inner: $0, scheduler: $0.scheduler) }
                 .transform(input: fromEnumProperty(\.timeTravel))
                 .transform(state: .init(lens: .init(\.timeTravel))),
         ])
     }
 
-    typealias EffectMapping = Harvester<Input, State>.EffectMapping<World, EffectQueue, EffectID>
+    typealias EffectMapping<S: Scheduler> = Harvester<Input, State>.EffectMapping<World<S>, EffectQueue, EffectID>
     typealias EffectQueue = CommonEffectQueue
     typealias EffectID = Root.EffectID
     typealias World = Harvest_SwiftUI_Gallery.World

--- a/Harvest-SwiftUI-Gallery/Utilities/DateUtil.swift
+++ b/Harvest-SwiftUI-Gallery/Utilities/DateUtil.swift
@@ -5,7 +5,9 @@ enum DateUtil {}
 
 extension DateUtil
 {
-    static func getDate<Input>(next: @escaping (Date) -> Input)
+    static func getDate<Input>(
+        next: @escaping (Date) -> Input
+    )
         -> (_ makeDate: @escaping () -> Date)
         -> AnyPublisher<Input, Never>
     {

--- a/Harvest-SwiftUI-Gallery/Utilities/ImageLoader.swift
+++ b/Harvest-SwiftUI-Gallery/Utilities/ImageLoader.swift
@@ -22,9 +22,7 @@ extension ImageLoader
         var isRequesting: [URL: Bool] = [:]
     }
 
-    static func effectMapping<S: Scheduler>(
-        scheduler: S
-    ) -> EffectMapping
+    static func effectMapping() -> EffectMapping
     {
         EffectMapping { input, state in
             var state = state
@@ -43,7 +41,6 @@ extension ImageLoader
                     ) { world in
                         self.fetchImage(request: Request(url: url), world: world)
                             .compactMap { $0.map { Input._cacheImage(url: url, image: $0.image) } }
-
                     }
 
                     return (state, effect)
@@ -77,7 +74,10 @@ extension ImageLoader
         let url: URL
     }
 
-    typealias World = URLSession
+    struct World
+    {
+        let urlSession: URLSession
+    }
 }
 
 extension ImageLoader
@@ -100,7 +100,7 @@ extension ImageLoader
         print("===> fetchImage = \(request.url)")
 
         let urlRequest = URLRequest(url: request.url)
-        return world.dataTaskPublisher(for: urlRequest)
+        return world.urlSession.dataTaskPublisher(for: urlRequest)
             .map { UIImage(data: $0.data).map { Response(image: $0) } }
             .replaceError(with: nil)
             .eraseToAnyPublisher()

--- a/Harvest-SwiftUI-Gallery/World.swift
+++ b/Harvest-SwiftUI-Gallery/World.swift
@@ -1,16 +1,40 @@
 import Foundation
+import Combine
 
 /// Dependencies that interacts with `Effect`s.
-struct World
+struct World<S: Scheduler>
 {
     let urlSession: URLSession
-    let date: () -> Date
+    let scheduler: S
+    let getDate: () -> Date
 
-    static func makeRealWorld() -> World
+    var github: GitHub.World<S>
     {
-        World(
-            urlSession: .shared,
-            date: { Date() }
+        GitHub.World(
+            urlSession: urlSession,
+            scheduler: scheduler,
+            searchRequestDelay: .seconds(0.3),
+            imageLoadMaxConcurrency: .max(3)
         )
     }
+
+    var stopwatch: Stopwatch.World<S>
+    {
+        Stopwatch.World(
+            getDate: getDate,
+            scheduler: scheduler
+        )
+    }
+}
+
+func makeRealWorld() -> World<DispatchQueue>
+{
+    let urlSession = URLSession.shared
+    let scheduler = DispatchQueue.main
+
+    return World<DispatchQueue>(
+        urlSession: urlSession,
+        scheduler: scheduler,
+        getDate: { Date() }
+    )
 }


### PR DESCRIPTION
Successor of #7, #8 .

This PR is a further work of #7 to remove `static func effectMapping`'s arguments (dirty dependency injection) to resurrect back to a pure function, since a better dependency injection can now be achieved by #8 controlling the `World` .
