### PR TITLE
Add `usesTimeTravel` flag

### DIFF
--- a/Harvest-SwiftUI-Gallery/SceneDelegate.swift
+++ b/Harvest-SwiftUI-Gallery/SceneDelegate.swift
@@ -18,12 +18,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
 
             let store = Store<DebugRoot.Input, DebugRoot.State>(
                 state: DebugRoot.State(Root.State(current: nil)),
-                mapping: DebugRoot.effectMapping(),
+                mapping: DebugRoot.effectMapping(usesTimeTravel: usesTimeTravel),
                 world: makeRealWorld()
             )
 
             window.rootViewController = UIHostingController(
-                rootView: AppView(store: store)
+                rootView: AppView(store: store, usesTimeTravel: usesTimeTravel)
             )
 
             self.window = window
@@ -31,3 +31,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate
         }
     }
 }
+
+private let usesTimeTravel: Bool = true

--- a/Harvest-SwiftUI-Gallery/Screens/AppView.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/AppView.swift
@@ -10,14 +10,17 @@ struct AppView: View
     @ObservedObject
     private var store: Store<DebugRoot.Input, DebugRoot.State>
 
-    init(store: Store<DebugRoot.Input, DebugRoot.State>)
+    private let usesTimeTravel: Bool
+
+    init(store: Store<DebugRoot.Input, DebugRoot.State>, usesTimeTravel: Bool = true)
     {
         self.store = store
+        self.usesTimeTravel = usesTimeTravel
     }
 
     var body: some View
     {
         // IMPORTANT: Pass `Store.Proxy` to children.
-        DebugRootView(store: self.store.proxy)
+        DebugRootView(store: self.store.proxy, usesTimeTravel: self.usesTimeTravel)
     }
 }

--- a/Harvest-SwiftUI-Gallery/Screens/DebugRootView.swift
+++ b/Harvest-SwiftUI-Gallery/Screens/DebugRootView.swift
@@ -5,20 +5,30 @@ import HarvestStore
 struct DebugRootView: View
 {
     private let store: Store<DebugRoot.Input, DebugRoot.State>.Proxy
+    private let usesTimeTravel: Bool
 
-    init(store: Store<DebugRoot.Input, DebugRoot.State>.Proxy)
+    init(store: Store<DebugRoot.Input, DebugRoot.State>.Proxy, usesTimeTravel: Bool = true)
     {
         self.store = store
+        self.usesTimeTravel = usesTimeTravel
     }
 
     var body: some View
     {
-        VStack {
-            RootView(store: self.store.timeTravel.inner.contramapInput { DebugRoot.Input.timeTravel(.inner($0)) })
+        let rootView = RootView(
+            store: self.store.timeTravel.inner
+                .contramapInput { DebugRoot.Input.timeTravel(.inner($0)) }
+        )
 
-            Divider()
-
-            debugBottomView()
+        return If(self.usesTimeTravel) {
+            VStack {
+                rootView
+                Divider()
+                self.debugBottomView()
+            }
+        }
+        .else {
+            rootView
         }
     }
 


### PR DESCRIPTION
Fixes the problems mentioned in https://github.com/inamiy/Harvest-SwiftUI-Gallery/issues/14#issuecomment-619478666 , #15, and possibly #16 .

> 1. Go to Stopwatch
> 2. Start Timer
> 3. Back to main list
> 4. Go to other screen
> 5. All events get delayed or malformed due to Stopwatch (heavy task) is still running

After investigation, the slowest task was not in `Stopwatch` but rather `TimeTravel` where **it collects all previous states as histories.**
With having a rapid event-flow, I discovered time-travelling will be the dominant cause of the UI glitches.
This can be simply solved by removing time-travelling feature.

In this PR, `usesTimeTravel` is introduced so that one can easily test `usesTimeTravel = false` case, which is the normal non-debug configuration. 